### PR TITLE
Fix too big progress bar #26

### DIFF
--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -38,10 +38,14 @@ module ProposalsHelper
   end
 
   private
-    PERCENTAGE_BAR_MAX_WIDTH = 200 # In pixels
+    VOTES_BAR_MAX_WIDTH = 200 # In pixels
+    LIMIT = 100
 
     def votes_bar_width(value)
-      value * PERCENTAGE_BAR_MAX_WIDTH / 100
+      if value >= LIMIT
+        VOTES_BAR_MAX_WIDTH
+      else
+        value * VOTES_BAR_MAX_WIDTH / LIMIT
+      end
     end
 end
-

--- a/spec/helpers/proposals_helper_spec.rb
+++ b/spec/helpers/proposals_helper_spec.rb
@@ -44,5 +44,15 @@ describe ProposalsHelper do
         helper.render_votes_bar(100).should include %{<div class="green" style="width: 200px"><span>100</span></div>}
       end
     end
+    context "when receives more than 100 votes" do
+      it "returns progress bar with 200px width" do
+        helper.render_votes_bar(136).should include %{<div class="green" style="width: 200px"><span>136</span></div>}
+      end
+    end
+    context "when receives more than 100 negatives votes" do
+      it "returns progress bar with 100px width" do
+        helper.render_votes_bar(-140).should include %{<div class="red" style="width: 200px"><span>140</span></div>}
+      end
+    end
   end
 end


### PR DESCRIPTION
Considering that progress bar box has 200px width, we calculate the width of progress bar based on it.
