### PR TITLE
fix broken behavior on user management event

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,6 +1,5 @@
 module EventsHelper
   def user_is_owner?(model)
-    user = @users.present? ? @users[model.user_id] : model.user
-    user_signed_in? && user == current_user
+    user_signed_in? && model.user == current_user
   end
 end

--- a/spec/feature/events_spec.rb
+++ b/spec/feature/events_spec.rb
@@ -129,6 +129,7 @@ feature "Events", %q{
       sign_in_with(user)
 
       event = FactoryGirl.create(:event, :user => user)
+      proposal = FactoryGirl.create(:proposal, :event => event)
 
       visit event_path(event)
 


### PR DESCRIPTION
After some user create one proposal, the event creator doesn't have the administrative tools anymore.
Fixed.
