### PR TITLE
Remove compass-rails dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :production do
 end
 
 group :assets do
-  gem 'compass-rails'
   gem 'sass-rails', '~> 3.2.0'
   gem 'uglifier'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,15 +58,8 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
-    chunky_png (1.2.7)
     coderay (1.1.0)
     columnize (0.8.9)
-    compass (0.12.2)
-      chunky_png (~> 1.2)
-      fssm (>= 0.2.7)
-      sass (~> 3.1)
-    compass-rails (1.0.3)
-      compass (>= 0.12.2, < 0.14)
     culerity (0.2.15)
     daemons (1.1.9)
     dalli (2.7.2)
@@ -111,7 +104,6 @@ GEM
       thor (~> 0.19.1)
     formatador (0.2.4)
     friendly_id (4.0.9)
-    fssm (0.2.10)
     haml (4.0.5)
       tilt
     hashie (1.2.0)
@@ -320,7 +312,6 @@ DEPENDENCIES
   byebug
   capybara
   carrierwave
-  compass-rails
   culerity
   dalli
   database_cleaner

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1,4 +1,3 @@
-@import 'compass/css3';
 @import "constants";
 
 .red_form { color: #f00; }
@@ -45,7 +44,7 @@ a:hover, a:active {
 }
 
 #menu{
-  @include border-radius(20px);
+  border-radius: 20px;
   background: #000;
   height: 70px;
 }
@@ -195,7 +194,7 @@ ul#menu_top li a:hover{
 
 .event{
   background: #fff;
-  @include border-radius(10px);
+  border-radius: 10px;
   width: 578px;
   height: 115px;
   padding: 20px;
@@ -374,7 +373,7 @@ ul#menu_top li a:hover{
 
 #proposal{
   background: #191817;
-  @include border-radius(10px);
+  border-radius: 10px;
   margin-bottom:20px;
   margin-top:20px;
   padding:10px;
@@ -384,10 +383,7 @@ ul#menu_top li a:hover{
 
 #profile{
   background: #000;
-  @include border-corner-radius(top,    left,  20px 30px);
-  @include border-corner-radius(top,    right, 20px 30px);
-  @include border-corner-radius(bottom, left,  20px 30px);
-  @include border-corner-radius(bottom, right, 20px 30px);
+  border-radius: 20px/30px;
   margin-bottom:20px;
   margin-top:20px;
   padding:10px;
@@ -408,7 +404,7 @@ img#user_picture{
 }
 
 .event_notice_area {
-  @include border-radius(5px);
+  border-radius: 5px;
   border: 1px solid lighten($vermelho, 20%);
   margin: 10px 10px 20px;
   padding: 10px;
@@ -442,7 +438,7 @@ img#user_picture{
 
 .prop{
   background: #fff;
-  @include border-radius(10px);
+  border-radius: 10px;
   margin-bottom:10px;
   padding: 20px 20px 120px 20px;
   width:581px;
@@ -529,7 +525,7 @@ a.prop_link:hover, a.prop_link:active{
 }
 
 .event_listed {
-  @include border-radius(20px);
+  border-radius: 20px;
   background: #FFF;
   width: 960px;
   height: 133px;

--- a/app/assets/stylesheets/widgets.css.scss
+++ b/app/assets/stylesheets/widgets.css.scss
@@ -1,10 +1,9 @@
-@import "compass/css3/border-radius";
 @import "constants";
 
 .btn-active {
   font-size: 18px;;
   display: inline-block;
-  @include border-radius(5px);
+  border-radius: 5px;
   color: white;
   background-color: lighten($vermelho, 10%);
   padding: 5px 10px;


### PR DESCRIPTION
Compass was only introduced to deal with `border-radius` with vendor prefixes,
but now this property is stable across all major browsers and a dependency of
this size is not required by the application anymore.
