### PR TITLE
An error prevented the creation of .env file. This has caused an error in the setup.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -90,7 +90,9 @@ for sample in $(find config -type f -maxdepth 1 -name '*.sample'); do
 done
 
 # env vars...
-if [[ -f config/.env ]]; then
+if [[ ! -f .env ]]; then
+  echo "Generating .env file"
+
   cp config/.env.template .env
 fi
 


### PR DESCRIPTION
The application never get into the instruction of creating the dot env because we had a problem with the file check.