### PR TITLE
Fix github oauth issues, set requested scopes in providers config

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :twitter, ENV['TWITTER_ACCESS'], ENV['TWITTER_SECRET']
-  provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_SECRET']
+  provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_SECRET'], scope: "user:email"
   provider :facebook, ENV['FACEBOOK_ACCESS'], ENV['FACEBOOK_KEY'],
            client_options: { ssl: { ca_file: '/usr/lib/ssl/certs/ca-certificates.crt' } }
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET']


### PR DESCRIPTION
This pull request fixes github oauth related in this [issue](https://github.com/call4paperz/call4paperz/issues/144), setting a [requested scope in ominiauth provider config](https://github.com/intridea/omniauth-github#scopes).

The problems occurs when any user non-authenticated by github, tries to log with github and doesn't was returning any user email, because is mandatory when app requires user's email, should be explicitly solicited through the [requested scopes](https://developer.github.com/v3/oauth/#scopes).

After that call4paperz was returning data of the last user with a null email.

