### PR TITLE
Set cache store to null for test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,4 +37,6 @@ Call4Paperz::Application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
+  config.cache_store = :null_store
 end


### PR DESCRIPTION
Test env should not store any cache. Currently, if you navigate in the home page then your test suite may fail. 

In the future we should avoid hitting any external service in the test suite.