### PR TITLE
Fix broken no_avatar default image

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,6 +1,6 @@
 module UserHelper
   def user_picture(user, options={})
-    if user.try(:picture).present?
+    if user.try(:picture)
       image_tag user.picture, options.merge(id: 'user_picture')
     else
       image_tag 'no_avatar.png', options

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,11 +42,7 @@ class User < ActiveRecord::Base
   end
 
   def picture
-    if photo?
-      photo.thumb.url
-    else
-      '/assets/no_avatar.png'
-    end
+    photo.thumb.url if photo?
   end
 
   def has_vote_for?(proposal)

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -1,30 +1,35 @@
 require 'spec_helper'
 
 describe UserHelper, :type => :helper do
-  context "#user_picture" do
+  context '#user_picture' do
     subject { helper.user_picture(user, {}) }
 
-    context "without an user" do
+    context 'without an user' do
       let(:user) { nil }
-      it { is_expected.to match("no_avatar.png") }
+
+      it { is_expected.to match('no_avatar.png') }
     end
 
-    context "user without picture" do
+    context 'user without picture' do
       let(:user) { FactoryGirl.build(:user, photo: nil) }
-      it { is_expected.to match("no_avatar.png") }
+
+      it { is_expected.to match('no_avatar.png') }
     end
 
-    context "user with picture" do
+    context 'user with picture' do
       let(:user) { FactoryGirl.build(:user) }
-      it do
+
+      before do
         allow(user).to receive(:picture).and_return(OpenStruct.new(thumb: '/path/123.png'))
-        is_expected.to match('123.png')
       end
+
+      it { is_expected.to match('123.png') }
     end
 
-    context "with options" do
+    context 'with options' do
       let(:user) { nil }
-      subject { helper.user_picture(user, :class => 'test') }
+      subject { helper.user_picture(user, class: 'test') }
+
       it { is_expected.to match('test') }
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe User, :type => :model do
 
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to have_many(:authentications).dependent(:destroy) }
     it { is_expected.to have_many(:comments).dependent(:destroy) }
     it { is_expected.to have_many(:events).dependent(:destroy) }
@@ -10,36 +10,37 @@ describe User, :type => :model do
     it { is_expected.to have_many(:votes).dependent(:destroy) }
   end
 
-  describe "devise validations overrides" do
-    context "password override" do
-      it "should not be valid if none is passed" do
+  describe 'devise validations overrides' do
+    context 'password override' do
+      it 'should not be valid if none is passed' do
         user = User.new
         expect(user).not_to be_valid
         expect(user.errors[:password].size).to eq 1
       end
 
-      it "should not require password when user has authentications and no password" do
+      it 'should not require password when user has authentications and no password' do
         user = User.new
         user.authentications.build(:provider => 'twitter', :uid => '123')
         expect(user).to be_valid
         expect(user.errors[:password].size).to eq 0
       end
 
-      it "should require password when user is being registered with password" do
+      it 'should require password when user is being registered with password' do
         user = User.new(:password => '123123', :password_confirmation => '123123')
         expect(user.errors[:password].size).to eq 0
       end
 
     end
-    context "email override" do
-      it "should not require email if it has authentications" do
+
+    context 'email override' do
+      it 'should not require email if it has authentications' do
         user = User.new
         user.authentications.build(:provider => 'twitter', :uid => '123')
         expect(user).to be_valid
         expect(user.errors[:email].size).to eq 0
       end
 
-      it "should require email if it has authentications " do
+      it 'should require email if it has authentications ' do
         user = User.new
         expect(user.valid?).to be false
         expect(user.errors[:email].size).to eq 1
@@ -47,11 +48,11 @@ describe User, :type => :model do
     end
   end
 
-  describe "photos" do
+  describe 'photos' do
     let(:user) { FactoryGirl.build(:user, photo: nil) }
 
-    context "when the user has a photo" do
-      it "shows the photo" do
+    context 'when the user has a photo' do
+      it 'shows the photo' do
         user.photo = File.open(Rails.root.join('spec', 'support', 'fixtures', 'guru_sp.png'))
         user.save!
 
@@ -59,9 +60,9 @@ describe User, :type => :model do
       end
     end
 
-    context "when the user has no photo" do
-      it "shows the no avatar image" do
-        expect(user.picture).to match /no_avatar/
+    context 'when the user has no photo' do
+      it 'returns nil' do
+        expect(user.picture).to be_nil
       end
     end
   end


### PR DESCRIPTION
`user` model should not deal with presentation logic. 

This PR removes the duplication of `no_avatar.png` default image condition. Actually, the image returned from `user.picture` was  `'/assets/no_avatar.png'` which path is wrong.

Removing the default image from user model, allows the `user_picture` helper method do its job.

part of #181 and also related to #182 