### PR TITLE
Add app volume to docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,5 @@ services:
     ports:
       - "3000:3000"
     command: bundle exec rails s -p 3000 --binding 0.0.0.0
+    volumes:
+      - .:/var/www/app


### PR DESCRIPTION
Add volume to docker-compose config. Files sync were not working without this config.

related to https://github.com/call4paperz/call4paperz/pull/189