### PR TITLE
Update docker configs and use ruby:2.4.1-slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM ruby:2.4.1
+FROM ruby:2.4.1-slim
 
-RUN apt-get update
-RUN apt-get install -y build-essential nodejs postgresql-client bundler
+RUN apt-get update && \
+    apt-get install -y build-essential nodejs libpq-dev postgresql-client imagemagick
 
-RUN mkdir -p /var/www/app
-WORKDIR /var/www/app
-COPY . /var/www/app
+ENV APP_PATH /var/www/app
 
-ENV BUNDLE_PATH=/var/www/app/.bundle
+WORKDIR $APP_PATH
+
+COPY Gemfile* $APP_PATH/
+
+ENV \
+  BUNDLE_GEMFILE=$APP_PATH/Gemfile \
+  BUNDLE_JOBS=2 \
+  BUNDLE_PATH=/var/www/app/.bundle
 
 RUN bundle install
+
+COPY . $APP_PATH/

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -1,10 +1,18 @@
 version: '2.0'
+
+volumes:
+  bundle_ruby241_slim:
+    driver: local
+
 services:
   db:
     volumes:
       - ./db_files:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
   web:
     volumes:
       - .:/var/www/app
+      - bundle_ruby241_slim:/var/www/app/.bundle:rw
     environment:
-      DB_USER: postgres 
+      DB_USER: postgres


### PR DESCRIPTION
Small improvements for development env with docker:

- use slim image, which is a bit smaller. the final image size is around: 900MB (before it was larger than 1GB)
- use a volume for gems caching
- fix gem bullet dependency `uniform_notifier (~> 1.10.0)`