### PR TITLE
Remove gem better_errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :production do
 end
 
 group :development do
-  gem 'better_errors'
   gem 'bullet'
   gem "letter_opener_web"
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,10 +46,6 @@ GEM
     airbrake-ruby (1.6.0)
     arel (6.0.4)
     bcrypt (3.1.11)
-    better_errors (2.1.1)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-      rack (>= 0.9.0)
     buftok (0.2.0)
     builder (3.2.3)
     bullet (5.6.1)
@@ -342,7 +338,6 @@ DEPENDENCIES
   active_model_serializers
   acts-as-taggable-on
   airbrake (~> 5.0)
-  better_errors
   bullet
   capybara
   carrierwave (~> 0.10.0)


### PR DESCRIPTION
`better_errors` was useful for rails 3, from rails 4 and beyond is a bit useless.