### PR TITLE
Remove mailcatcher from Procfile.development

### DIFF
--- a/Procfile.development
+++ b/Procfile.development
@@ -1,2 +1,1 @@
 web: bundle exec rails s
-mailcatcher: mailcatcher --foreground


### PR DESCRIPTION
We don't use mailcatcher anymore. 