### PR TITLE
Update Docker image to ruby:2.5.1-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.2-slim
+FROM ruby:2.5.1-slim
 
 RUN apt-get update && \
     apt-get install -y build-essential nodejs libpq-dev postgresql-client imagemagick


### PR DESCRIPTION
We forgot to update the ruby image here: https://github.com/call4paperz/call4paperz/commit/0bd34a7a6f774e1c63b4396dda53b26de999e99c

Gemfile ruby: https://github.com/call4paperz/call4paperz/blob/master/Gemfile#L3