### PR TITLE
Update sprockets to version 3.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Fix security warning `CVE-2018-3760`: https://hakiri.io/github/call4paperz/call4paperz/master/c12e1d561d22d44e6b1a94fbeb91e43f26abe499/warnings?name=Information+Disclosure