### PR TITLE
Bugfix hidden sign up button

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -739,7 +739,7 @@ a.prop_link:hover, a.prop_link:active{
 }
 
 #new_item input[type=image] {
-  margin: 10px 0;
+  margin: 50px 0 0 0;
 }
 
 #new_item textarea {


### PR DESCRIPTION
Problem:
Fixed hidden button issue.

Solution:

Adjusted the CSS of the button, when captcha loads the button is behind it, making it impossible to click the sign up button.

Issue: https://github.com/call4paperz/call4paperz/issues/340

![Screen Shot 2019-10-18 at 13 40 37](https://user-images.githubusercontent.com/1836802/67112140-ec249480-f1ac-11e9-97ac-9b35f59f5ce4.png)
