### PR TITLE
Refactor Docker configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ WORKDIR $APP_PATH
 
 COPY Gemfile* $APP_PATH/
 
-ENV \
-  BUNDLE_GEMFILE=$APP_PATH/Gemfile \
-  BUNDLE_JOBS=2 \
-  BUNDLE_PATH=/var/www/app/.bundle
-
 RUN bundle install
 
 COPY . $APP_PATH/

--- a/README.md
+++ b/README.md
@@ -57,28 +57,19 @@ Then start the server with the following command:
 $ foreman start -f Procfile.development
 ```
 
-## When using docker
+## Running with Docker
 
-At the time of writing it, it was tested with versions:
+We strongly encourage Docker usage. With Docker, we can standardize the development environment, quickly rebuilding it whenever necessary without installing anything on the host machine.
 
-For Docker Engine: 1.12.5
+A straight forward  `Dockerfile` based on an official Ruby base image is provided. Also, the Docker Compose configurations provided, help considerably running the Docker commands.
 
-For Docker Compose: 1.6.2
-
-### For development environment
-
-When in development environment, it can be useful to have some extra configs,
-like volumes to keep the application directory synced and avoid losing database files.
-
-In docker-compose.override.yml.sample exists some of those extra configs, so you
-can run the command below to make use of it:
+You can have full control of the Docker Compose configs in your development environment, we provide a sample file, and just the environment variables are required.
 
 `$ cp docker-compose.override.yml.sample docker-compose.override.yml`
 
 ### Setup
 
-After you're done with specific environment's steps,
-to setup the application, you need to run:
+After setting up the Docker Compose configuration, to set up the application, you need to run:
 
 ```
 $ docker-compose run --rm web bin/setup
@@ -86,8 +77,7 @@ $ docker-compose run --rm web bin/setup
 
 ### Running the application
 
-Now that all setup steps are done, you only need to run the command below
-to get the application running:
+Now that all setup steps are done, you only need to run the command below to get the application running:
 
 ```
 $ docker-compose up

--- a/README.md
+++ b/README.md
@@ -49,14 +49,6 @@ Repeat until all the stuff is in place.
 Edit the file `.env` generated in the project's root dir and add your keys for
 twitter and facebook applications.
 
-### PostgreSQL
-
-The setup will create a `config/database.yml`, the user configuration will point
-to your current s.o. user.
-
-Edit this file if you need, or if the setup process fail trying to use the
-credentials auto generated.
-
 ### let's go!
 
 Then start the server with the following command:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,14 +1,11 @@
 development:
   adapter: postgresql
-  database: <%= ENV.fetch('DB_NAME', 'DBNAME') %>
-  username: <%= ENV.fetch('DB_USER', 'USER') %>
-  password:
+  database: <%= ENV.fetch('DB_NAME', 'call4paperz_development') %>
+  username: <%= ENV.fetch('DB_USER', 'postgres') %>
   host: <%= ENV.fetch('DB_HOST', 'localhost') %>
-  min_messages: WARNING
+
 test:
   adapter: postgresql
   database: call4paperz_test
   username: <%= ENV.fetch('DB_USER', 'USER') %>
-  password:
   host: <%= ENV.fetch('DB_HOST', 'localhost') %>
-  min_messages: WARNING

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -1,18 +1,28 @@
-version: '2.0'
+version: '3'
 
 volumes:
-  bundle_ruby242_slim:
+  dbdata:
     driver: local
 
 services:
   db:
     volumes:
-      - ./db_files:/var/lib/postgresql/data
+      - dbdata:/var/lib/postgresql/data:rw
     ports:
-      - "5432:5432"
+      - 5432:5432
+
   web:
     volumes:
       - .:/var/www/app
-      - bundle_ruby242_slim:/var/www/app/.bundle:rw
+    ports:
+      - 3000:3000
+    command:
+      - bin/rails
+      - server
+      - --port
+      - '3000'
+      - --binding
+      - 0.0.0.0
     environment:
+      DB_HOST: db
       DB_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,3 @@ services:
       context: .
     depends_on:
       - db
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
-version: '2.0'
+version: '3'
+
 services:
   db:
-    image: postgres
+    image: postgres:alpine
+
   web:
-    build: .
+    build:
+      context: .
     depends_on:
       - db
-    environment:
-      DB_HOST: "db"
-    ports:
-      - "3000:3000"
-    command: bundle exec rails s -p 3000 --binding 0.0.0.0
+


### PR DESCRIPTION
Update the Docker configurations used for development.

- Remove the volume for caching gems. It's not necessary anymore. When we update Ruby or any gem, it's easy to re-build the image from scratch.
- Cleans up the database config.
- Use the `alpine` image for postgres, which is a small image.

For the next steps, we could use the same image to run tests on CircleCI.