### PR TITLE
Add Code Climate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,20 @@
+engines:
+  brakeman:
+    enabled: true
+  bundler-audit:
+    enabled: true
+  csslint:
+    enabled: true
+  duplication:
+    enabled: true
+    exclude_paths:
+      - 'vendor/'
+      - 'spec/'
+      - 'db/'
+    config:
+      languages:
+      - ruby
+      - javascript
+  rubocop:
+    enabled: true
+    channel: rubocop-0-74


### PR DESCRIPTION
Add a few cops to Code Climate, including Rubocop 0.74 in order to support Ruby 2.6.

Related PR: https://github.com/call4paperz/call4paperz/pull/347